### PR TITLE
add celerybit pidfile option in bin/

### DIFF
--- a/bin/celery-beat
+++ b/bin/celery-beat
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec celery beat -A cabot --loglevel=INFO
+exec celery beat -A cabot --loglevel=INFO --pidfile=


### PR DESCRIPTION
default uses a file at the root of the cabot home dir, difficult to mount with docker
